### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.2.0 - 2023-12-11
+
+### Fixed
+
+- Fixed project `key` value so we properly ingest sonarcloud_issue entities.
+
 ## 1.1.2 - 2023-12-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-sonarcloud",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A JupiterOne Integration for ingesting data of the SonarCloud",
   "repository": {
     "type": "git",

--- a/src/steps/issues/index.ts
+++ b/src/steps/issues/index.ts
@@ -11,7 +11,6 @@ import { createProjectIssueRelationship, createIssueEntity } from './converter';
 export async function fetchIssues({
   instance,
   jobState,
-  logger,
 }: IntegrationStepExecutionContext<IntegrationConfig>) {
   const apiClient = createAPIClient(instance.config);
 
@@ -25,15 +24,8 @@ export async function fetchIssues({
       await apiClient.iterateProjectIssues(
         projectKey as string,
         async (issue) => {
-          logger.info('Ingested a SonarCloud Issue: ', issue.key);
-
           const issueEntity = await jobState.addEntity(
             createIssueEntity(issue),
-          );
-
-          logger.info(
-            'Adding a sonarcloud_issue entity to jobState',
-            issueEntity._key,
           );
 
           await jobState.addRelationship(

--- a/src/steps/projects/converter.ts
+++ b/src/steps/projects/converter.ts
@@ -23,7 +23,7 @@ export function createProjectEntity(project: SonarCloudProject): Entity {
         _type: Entities.PROJECT._type,
         _class: Entities.PROJECT._class,
         _key: id,
-        key: project.name,
+        key: project.key,
         name: project.name,
         public: project.visibility === 'public',
         qualifier: project.qualifier,


### PR DESCRIPTION
We were previously saving the project's _name_ at `project.key`. This lead to problems when trying to get issues for projects. Specifically, if a user has not manually went in and updated their project's key to be exactly the name (which is not the default behavior), then our query to `/issues/search?projects=${project}` would result in an empty list, as that route requires you pass the project _key_, not name.
